### PR TITLE
Remove script tags for clean JS

### DIFF
--- a/app/views/spree/shared/_google_add_items.html.erb
+++ b/app/views/spree/shared/_google_add_items.html.erb
@@ -1,15 +1,13 @@
-<script>
-  if (typeof ga !== 'undefined') {
-    <% @order.line_items.each do |line_item| %>
-    ga('ec:addProduct', {               // Provide product details in a productFieldObject.
-      'id': '<%= j (line_item.sku.present? ? line_item.sku : line_item.variant_id.to_s) %>',  // Product ID (string).
-      'name': '<%= j line_item.name %>', // Product name (string).
-      'category': '<%= j line_item.category.try(:name) %>',            // Product category (string).
-      'brand': '<%= j line_item.brand.try(:name) %>',                // Product brand (string).
-      'variant': '<%= j line_item.options_text %>',               // Product variant (string).
-      'price': '<%= line_item.price %>',
-      'quantity': <%= line_item.quantity %>
-    });
-    <% end %>
-  }
-</script>
+if (typeof ga !== 'undefined') {
+  <% @order.line_items.each do |line_item| %>
+  ga('ec:addProduct', {               // Provide product details in a productFieldObject.
+    'id': '<%= j (line_item.sku.present? ? line_item.sku : line_item.variant_id.to_s) %>',  // Product ID (string).
+    'name': '<%= j line_item.name %>', // Product name (string).
+    'category': '<%= j line_item.category.try(:name) %>',            // Product category (string).
+    'brand': '<%= j line_item.brand.try(:name) %>',                // Product brand (string).
+    'variant': '<%= j line_item.options_text %>',               // Product variant (string).
+    'price': '<%= line_item.price %>',
+    'quantity': <%= line_item.quantity %>
+  });
+  <% end %>
+}


### PR DESCRIPTION
The recent Spree bump to v3.5.0 triggers this https://github.com/spree-contrib/spree_analytics_trackers/blob/c1b106514a6296d2bbb3ad843fd009915e8977a6/app/overrides/add_google_checkout_to_checkout_edit.rb#L1

the `script` tags on the `_google_add_items.html.erb` partial results in malformed JS.  This PR is the fix. 

```
<script>
  if (typeof ga !== 'undefined') {
    ga('require', 'ec');
    ga('set', '&cu', 'USD');

    <script>
  if (typeof ga !== 'undefined') {
    ga('ec:addProduct', {               // Provide product details in a productFieldObject.
      'id': '11',  // Product ID (string).
      'name': 'Discount Cards (100 Count)', // Product name (string).
      'category': '',            // Product category (string).
      'brand': '',                // Product brand (string).
      'variant': '',               // Product variant (string).
      'price': '10.0',
      'quantity': 1
    });
  }




    // Add the step number and additional info about the checkout to the action.
    ga('ec:setAction','checkout', {
      'step': 4
    });
  }
</script>
```
