### PR TITLE
Fix purchase tracking

### DIFF
--- a/app/views/spree/shared/trackers/google_analytics/_purchase.js.erb
+++ b/app/views/spree/shared/trackers/google_analytics/_purchase.js.erb
@@ -9,7 +9,7 @@
         shipping: '<%= @order.shipment_total %>',
         items: [
           <% @order.line_items.each do |line_item| %>
-            <%= ga_line_item(line_item) %>
+            <%= ga_line_item(line_item) %>,
           <% end %>
         ]
       });


### PR DESCRIPTION
When there are multiple items in the cart, the javascript generated is
invalid because no commas separate the line items.  This fix adds the missing
comma.