### PR TITLE
Fix Checkout Step type

### DIFF
--- a/app/views/spree/shared/trackers/google_analytics/_checkout_step_viewed.js.erb
+++ b/app/views/spree/shared/trackers/google_analytics/_checkout_step_viewed.js.erb
@@ -11,7 +11,7 @@
     });
 
     gtag('event', 'set_checkout_option', {
-      'checkout_step': '<%= (@order.checkout_steps.index(@order.state) + 1) %>',
+      'checkout_step': <%= (@order.checkout_steps.index(@order.state) + 1) %>,
       'checkout_option': '<%= @order.state %>'
     });
   };


### PR DESCRIPTION
when sending checkout_step through gtag for ecommerce, according to this
documentation, the type should be "number", not "string", so send as a
number.

https://developers.google.com/analytics/devguides/collection/gtagjs/enhanced-ecommerce#action_data