### PR TITLE
fix checkout progress tracking

### DIFF
--- a/app/views/spree/shared/trackers/google_analytics/_checkout_step_viewed.js.erb
+++ b/app/views/spree/shared/trackers/google_analytics/_checkout_step_viewed.js.erb
@@ -1,6 +1,7 @@
 <script>
   if (typeof gtag !== 'undefined') {
     gtag('event', 'checkout_progress', {
+      checkout_step: <%= (@order.checkout_steps.index(@order.state) + 1) %>,
       items: [
         <% @order.line_items.each do |line_item| %>
           <%= ga_line_item(line_item) %>,
@@ -8,11 +9,6 @@
       ],
 
       coupon: '<%= @order.promo_code %>',
-    });
-
-    gtag('event', 'set_checkout_option', {
-      'checkout_step': <%= (@order.checkout_steps.index(@order.state) + 1) %>,
-      'checkout_option': '<%= @order.state %>'
     });
   };
 </script>


### PR DESCRIPTION
the code was incorrectly calling set_checkout_option to try and set the
checkout_step when the correct methodology is to set the checkout_step
in the checkout_progress event.

https://developers.google.com/gtagjs/reference/event

(see parameters to checkout_progress event in first table)