### PR TITLE
Make 'confirm' a reported checkout step

### DIFF
--- a/app/overrides/add_checkout_step_viewed_to_checkout_edit.rb
+++ b/app/overrides/add_checkout_step_viewed_to_checkout_edit.rb
@@ -3,7 +3,7 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
   Deface::Override.new(
     virtual_path: 'spree/checkout/edit',
     name: 'add_segment_checkout_step_viewed_to_checkout_edit',
-    insert_bottom: "[data-hook='checkout_summary_box']",
+    insert_bottom: "[data-hook='checkout_content']",
     partial: 'spree/shared/trackers/segment/checkout_step_viewed.js',
     original: 'f7b787e3485b705d0373e248361fcb590a45478e'
   )
@@ -11,7 +11,7 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
   Deface::Override.new(
     virtual_path: 'spree/checkout/edit',
     name: 'add_ga_checkout_step_viewed_to_checkout_edit',
-    insert_bottom: "[data-hook='checkout_summary_box']",
+    insert_bottom: "[data-hook='checkout_content']",
     partial: 'spree/shared/trackers/google_analytics/checkout_step_viewed.js'
   )
 end


### PR DESCRIPTION
The confirm step doesn't have a checkout_summary so target the parent data-hook instead to capture all checkout steps.