### PR TITLE
Add coupon to google analytics purchase

### DIFF
--- a/app/views/spree/shared/trackers/google_analytics/_purchase.js.erb
+++ b/app/views/spree/shared/trackers/google_analytics/_purchase.js.erb
@@ -7,6 +7,7 @@
         currency: '<%= @order.currency %>',
         tax: '<%= @order.tax_total %>',
         shipping: '<%= @order.shipment_total %>',
+        coupon: '<%= @order.promo_code %>',
         items: [
           <% @order.line_items.each do |line_item| %>
             <%= ga_line_item(line_item) %>,


### PR DESCRIPTION
Following same logic as having coupons in checkout steps, it was missing from the purchase page.  Segment already has this, was just missing for Google Analytics.