### PR TITLE
[SD-909] Merges two events for checkout step view to avoid GA error

### DIFF
--- a/app/views/spree/shared/trackers/google_analytics/_checkout_step_viewed.js.erb
+++ b/app/views/spree/shared/trackers/google_analytics/_checkout_step_viewed.js.erb
@@ -10,11 +10,7 @@
         ],
 
         coupon: '<%= @order.promo_code %>',
-      });
-
-      gtag('event', 'set_checkout_option', {
-        'checkout_step': '<%= (@order.checkout_steps.index(@order.state) + 1) %>',
-        'checkout_option': '<%= @order.state %>'
+        checkout_option: '<%= @order.state %>'
       });
     };
   </script>


### PR DESCRIPTION
Prevents `Plugin "ec" has already been required` GA error occurring when two events in one partial were present.