### PR TITLE
call analytics.track() on order completed page

### DIFF
--- a/app/views/spree/shared/trackers/segment/_order_complete.js.erb
+++ b/app/views/spree/shared/trackers/segment/_order_complete.js.erb
@@ -3,6 +3,7 @@
   <script>
     if (typeof analytics !== 'undefined') {
       analytics.page('Order Completed', <%= order_json.html_safe %>);
+      analytics.track('Order Completed', <%= order_json.html_safe %>);
     }
   </script>
 <% end %>


### PR DESCRIPTION
I found this needed with Segment -> Klaviyo destination setup - made available to track an event of complete and order for particular user