### PR TITLE
Include Google Analytics and Segment initializers only once within the head section …

### DIFF
--- a/app/overrides/add_google_analytics_to_spree_application.rb
+++ b/app/overrides/add_google_analytics_to_spree_application.rb
@@ -2,7 +2,7 @@ if Gem.loaded_specs['spree_core'].version >= Gem::Version.create('3.5.0.alpha')
   Deface::Override.new(
     virtual_path: 'spree/shared/_head',
     name: 'add_google_analytics_initializer_to_spree_application',
-    insert_before: 'meta',
+    insert_after: 'title',
     partial: 'spree/shared/trackers/google_analytics/initializer.js',
     original: 'cfa30a2831d9a41394c03229cd28b3c7eee69585'
   )

--- a/app/overrides/add_segment_initializer_to_layout.rb
+++ b/app/overrides/add_segment_initializer_to_layout.rb
@@ -3,7 +3,7 @@ unless spree_version >= Gem::Version.create('3.3.0') && spree_version < Gem::Ver
   Deface::Override.new(
     virtual_path: 'spree/shared/_head',
     name: 'add_segment_initializer_to_layout',
-    insert_before: 'meta',
+    insert_after: 'title',
     partial: 'spree/shared/trackers/segment/initializer.js',
     original: '6841b819babbe4df1f03d0bc8e05dc81bf0d45ad'
   )


### PR DESCRIPTION
…of frontend layout view.

Currently initializer.js scripts both for GA and Segment can be included multiple times, once for each `<meta>` occurrence within a HTML page body (keyword, description, viewport, charset etc.)

Considering Segment integration, this can produce JS console errors (as can be seen below, there is a safeguard against such a case in the segment.js source code however still it's a good practice not to include obsolete JS snippets.

[analytics.js source](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/quickstart/#step-2-copy-the-segment-snippet)
```
<script type="text/javascript">
  (function(){
    ...
    // If the snippet was invoked already show an error.
    if (analytics.invoked) {
      if (window.console && console.error) {
        console.error('Segment snippet included twice.');
      }
      return;
    }
    ...    
```
I am not sure if some similar safeguard mechanism exists for Google Analytics.