### PR TITLE
fix: add compatibility with rails 7 on partials with format js

### DIFF
--- a/app/overrides/add_cart_viewed_to_orders_edit.rb
+++ b/app/overrides/add_cart_viewed_to_orders_edit.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/orders/edit',
     name: 'add_cart_viewed_to_orders_edit',
     insert_top: '[data-hook="cart_container"]',
-    partial: 'spree/shared/trackers/segment/cart_viewed.js',
-    original: 'e0a3dcdf759c4ec9fad085cd8a5360c8d68167f5'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/cart_viewed', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_checkout_step_viewed_to_checkout_edit.rb
+++ b/app/overrides/add_checkout_step_viewed_to_checkout_edit.rb
@@ -4,15 +4,17 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/checkout/edit',
     name: 'add_segment_checkout_step_viewed_to_checkout_edit',
     insert_after: '[data-hook="checkout_content"]',
-    partial: 'spree/shared/trackers/segment/checkout_step_viewed.js',
-    original: '806d2120a1ca1050fb093962fee10363c0944b0a'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/checkout_step_viewed', formats: :js %>
+    HTML
   )
 
   Deface::Override.new(
     virtual_path: 'spree/checkout/edit',
     name: 'add_ga_checkout_step_viewed_to_checkout_edit',
     insert_after: '[data-hook="checkout_content"]',
-    partial: 'spree/shared/trackers/google_analytics/checkout_step_viewed.js',
-    original: '0ac5c18a2db215bf8ba30470a0e5d69e00d0313a'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/checkout_step_viewed', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_page_view_to_spree_application.rb
+++ b/app/overrides/add_google_analytics_page_view_to_spree_application.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.3.0') && spree_version < Gem::Ver
     virtual_path: 'spree/shared/_head',
     name: 'add_google_analytics_page_viewed_to_spree_application',
     insert_before: 'meta',
-    partial: 'spree/shared/trackers/google_analytics/page_viewed.js',
-    original: '6841b819babbe4df1f03d0bc8e05dc81bf0d45ad'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/page_viewed', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_to_spree_application.rb
+++ b/app/overrides/add_google_analytics_to_spree_application.rb
@@ -3,7 +3,8 @@ if Gem.loaded_specs['spree_core'].version >= Gem::Version.create('3.5.0.alpha')
     virtual_path: 'spree/shared/_head',
     name: 'add_google_analytics_initializer_to_spree_application',
     insert_after: 'title',
-    partial: 'spree/shared/trackers/google_analytics/initializer.js',
-    original: 'cfa30a2831d9a41394c03229cd28b3c7eee69585'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/initializer', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_purchase_to_orders_show.rb
+++ b/app/overrides/add_google_purchase_to_orders_show.rb
@@ -3,7 +3,8 @@ if Gem.loaded_specs['spree_core'].version >= Gem::Version.create('3.5.0')
     virtual_path: 'spree/orders/show',
     name: 'add_google_purchase_to_orders_show',
     insert_before: "#order_summary",
-    partial: 'spree/shared/trackers/google_analytics/purchase.js',
-    original: 'ac7f302922a3c1bb080095296ccc20e42bab2967' 
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/purchase', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_order_complete_to_orders_show.rb
+++ b/app/overrides/add_order_complete_to_orders_show.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.3.0') && spree_version < Gem::Ver
     virtual_path: 'spree/orders/show',
     name: 'add_order_complete_to_orders_show',
     insert_before: "#order_summary",
-    partial: 'spree/shared/trackers/segment/order_complete.js',
-    original: 'ac7f302922a3c1bb080095296ccc20e42bab2967' 
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/order_complete', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_product_list_filtered_to_taxons_show.rb
+++ b/app/overrides/add_product_list_filtered_to_taxons_show.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/taxons/_header',
     name: 'add_product_list_filtered_to_taxons_show',
     insert_before: ".taxon-title",
-    original: '2d71d85f4cb141a6ff90264e48915493d6856e9b',
-    partial: 'spree/shared/trackers/segment/product_list_filtered.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/product_list_filtered', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_product_list_viewed_to_products_list.rb
+++ b/app/overrides/add_product_list_viewed_to_products_list.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/shared/_products',
     name: 'add_product_list_viewed_to_products_list',
     insert_before: '[data-hook="homepage_products"]',
-    partial: 'spree/shared/trackers/segment/product_list_viewed.js',
-    original: '8b47dddca9dfaaacca3d462459c6c1ef06c09926' 
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/product_list_viewed', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_product_viewed_to_products_show.rb
+++ b/app/overrides/add_product_viewed_to_products_show.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/products/show',
     name: 'add_product_viewed_to_products_show',
     insert_bottom: '[data-hook="product_show"]',
-    partial: 'spree/shared/trackers/segment/product_viewed.js',
-    original: '5426c263ccfe477b270b55024abebc77cf951c91'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/product_viewed', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_products_searched_to_products_list.rb
+++ b/app/overrides/add_products_searched_to_products_list.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/products/index',
     name: 'add_products_searched_to_products_list',
     insert_before: '[data-hook="search_results"]',
-    partial: 'spree/shared/trackers/segment/products_searched.js',
-    original: '8b47dddca9dfaaacca3d462459c6c1ef06c09926' 
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/products_searched', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_segment_initializer_to_layout.rb
+++ b/app/overrides/add_segment_initializer_to_layout.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.3.0') && spree_version < Gem::Ver
     virtual_path: 'spree/shared/_head',
     name: 'add_segment_initializer_to_layout',
     insert_after: 'title',
-    partial: 'spree/shared/trackers/segment/initializer.js',
-    original: '6841b819babbe4df1f03d0bc8e05dc81bf0d45ad'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/initializer', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_segment_page_viewed_to_layout.rb
+++ b/app/overrides/add_segment_page_viewed_to_layout.rb
@@ -4,7 +4,8 @@ unless spree_version >= Gem::Version.create('3.3.0') && spree_version < Gem::Ver
     virtual_path: 'spree/shared/_head',
     name: 'add_segment_page_tracker_to_body',
     insert_before: 'meta',
-    partial: 'spree/shared/trackers/segment/page_viewed.js',
-    original: '6841b819babbe4df1f03d0bc8e05dc81bf0d45ad'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/segment/page_viewed', formats: :js %>
+    HTML
   )
 end


### PR DESCRIPTION
Having an extension in the partial name was deprecated in Rails 6.1 and removed in Rails 7.

source: https://stackoverflow.com/a/71069848