### PR TITLE
Partials loading fix for Rails 7 / Spree ~> 4.6

### DIFF
--- a/app/overrides/add_google_analytics_add_shipping_info_to_payment.rb
+++ b/app/overrides/add_google_analytics_add_shipping_info_to_payment.rb
@@ -4,6 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/checkout/_payment',
     name: 'add_google_analytics_add_shipping_info_to_payment',
     insert_bottom: '[data-hook="checkout_payment_step"]',
-    partial: 'spree/shared/trackers/google_analytics/add_shipping_info.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/add_shipping_info', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_begin_application_to_registration.rb
+++ b/app/overrides/add_google_analytics_begin_application_to_registration.rb
@@ -4,6 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/user_registrations/new',
     name: 'add_google_analytics_begin_application_to_registration',
     insert_bottom: '[data-hook="wholesale_login_extras"]',
-    partial: 'spree/shared/trackers/google_analytics/begin_application.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/begin_application', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_begin_checkout_to_address.rb
+++ b/app/overrides/add_google_analytics_begin_checkout_to_address.rb
@@ -4,6 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/checkout/_address',
     name: 'add_google_analytics_begin_checkout_to_address',
     insert_bottom: '[data-hook="checkout_address_step"]',
-    partial: 'spree/shared/trackers/google_analytics/begin_checkout.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/begin_checkout', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_contact_info_added_to_store_address.rb
+++ b/app/overrides/add_google_analytics_contact_info_added_to_store_address.rb
@@ -4,6 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/addresses/new_wholesale',
     name: 'add_google_analytics_contact_info_added_to_store_address',
     insert_bottom: '[data-hook="new_wholesale_address"]',
-    partial: 'spree/shared/trackers/google_analytics/contact_info_added.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/contact_info_added', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_generate_lead_to_store_address.rb
+++ b/app/overrides/add_google_analytics_generate_lead_to_store_address.rb
@@ -4,6 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/addresses/new_wholesale',
     name: 'add_google_analytics_generate_lead_to_store_address',
     insert_bottom: '[data-hook="new_wholesale_address"]',
-    partial: 'spree/shared/trackers/google_analytics/generate_lead.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/generate_lead', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_sign_up_to_contact_information.rb
+++ b/app/overrides/add_google_analytics_sign_up_to_contact_information.rb
@@ -4,6 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/wholesalers/new',
     name: 'add_google_analytics_sign_up_to_contact_information',
     insert_bottom: '[data-hook="wholesaler_inside_form"]',
-    partial: 'spree/shared/trackers/google_analytics/sign_up.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/sign_up', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_google_analytics_view_item_list_to_products.rb
+++ b/app/overrides/add_google_analytics_view_item_list_to_products.rb
@@ -4,6 +4,8 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
     virtual_path: 'spree/shared/_products',
     name: 'add_google_analytics_view_item_list_to_products',
     insert_after: '[data-hook="homepage_products"]',
-    partial: 'spree/shared/trackers/google_analytics/product_list_viewed.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/product_list_viewed', formats: :js %>
+    HTML
   )
 end

--- a/app/overrides/add_product_viewed_to_products_show.rb
+++ b/app/overrides/add_product_viewed_to_products_show.rb
@@ -8,11 +8,13 @@ unless spree_version >= Gem::Version.create('3.4.0') && spree_version < Gem::Ver
       <%= render partial: 'spree/shared/trackers/segment/product_viewed', formats: :js %>
     HTML
   )
-  
+
   Deface::Override.new(
     virtual_path: 'spree/products/show',
     name: 'add_product_viewed_to_products_show',
     insert_bottom: '[data-hook="product_show"]',
-    partial: 'spree/shared/trackers/google_analytics/product_viewed.js'
+    text: <<-HTML
+      <%= render partial: 'spree/shared/trackers/google_analytics/product_viewed', formats: :js %>
+    HTML
   )
 end


### PR DESCRIPTION
Apparently not all overrides had partial loading logic ported to `text` which was causing some screens to throw exceptions on Rails 7 / Spree 4.6.